### PR TITLE
BounceBounceRevolution 4: Brodyquest

### DIFF
--- a/js/berrymotes.js
+++ b/js/berrymotes.js
@@ -221,11 +221,11 @@ function applyAnimation(emote, $emote) {
 }
 
 function wrapEmoteHeight($emote, height) {
-    var offset = (height-$emote.height())/2;
+    var offset = Math.floor((height-$emote.height())/2);
     $emote.wrap('<span class="rotation-wrapper" />').parent().css({
         'height': Math.ceil(height - offset),
         'display': 'inline-block',
-        'margin-top': Math.floor(offset),
+        'margin-top': offset,
         'position': 'relative'});
 }
 
@@ -389,7 +389,7 @@ function postEmoteEffects(message, isSearch, ttl, username) {
                 }
                 if (berryEnableBrody && (flags[i] == 'brody')) {
                     animations.push('brody  1.27659s infinite ease');
-                    var brody_height = $emote.width()*Math.sin(10*Math.PI/180) + $emote.height()*Math.cos(10*Math.PI/180);
+                    var brody_height = 1.01*($emote.width()*Math.sin(10*Math.PI/180) + $emote.height()*Math.cos(10*Math.PI/180));
                     wrapEmoteHeight($emote, brody_height);
                 }
             }


### PR DESCRIPTION
Cautiously apply fudge factors to hopefully kill off remaining bounce in -brody without creating clownshoes

Sort of tested by live editing CSS on the test site, but no guarantee that this will work for every emote. Fudge factor might need further fudging.
