### PR TITLE
Allow blacklist entries to be subreddits in the form of /r/srname

### DIFF
--- a/js/berrymotes.core.js
+++ b/js/berrymotes.core.js
@@ -239,6 +239,10 @@ Bem = typeof Bem === "undefined" ? {} : Bem;
             if (emote.names.indexOf($.trim(Bem.blacklist[j])) > -1) {
                 eligible = false;
             }
+            // allow subreddit blacklisting
+            if ('/r/'+emote.sr == $.trim(Bem.blacklist[j])) {
+                eligible = false;
+            }
         }
         if (Bem.showNsfwEmotes === false && emote.nsfw) eligible = false;
         if (emote.com && Bem.community != emote.com) eligible = false;


### PR DESCRIPTION
Simple change to the blacklist form, no additional changes to the GUI or logic required, just allows subreddits to be used as blacklist entries along side specific emotes.
