### PR TITLE
Prevent emoting of already loaded chat messages if emotes are disabled.

### DIFF
--- a/js/berrymotes.berrytube.js
+++ b/js/berrymotes.berrytube.js
@@ -52,6 +52,11 @@ Bem.berrySiteInit = function () {
             Bem.loggingIn = true;
         });
 
+        if (!Bem.enabled){
+            // do not emote existing chat messages if emotes are disabled
+            return null;
+        }
+
         function handleText(node) {
             Bem.applyEmotesToTextNode(node);
         }


### PR DESCRIPTION
Pretty much what the title says. Just checking if emotes are enabled before walking though the chat emoting things.
