### PR TITLE
Handle protocol independent urls

### DIFF
--- a/emotescraper/bmscraper/scraper.py
+++ b/emotescraper/bmscraper/scraper.py
@@ -96,7 +96,7 @@ class BMScraper(FileNameUtils):
                 file_path = self.get_file_path(image_url, rootdir=self.cache_dir)
                 if not os.path.isfile(file_path):
                     # Temp workaround for downloading apngs straight from amazon instead of broken ones from cloudflare
-                    image_url = image_url.replace('http://', 'https://s3.amazonaws.com/')
+                    image_url = re.sub(r'^(https?:)?//', 'https://s3.amazonaws.com/', image_url)
                     workpool.put(DownloadJob(self._requests,
                                              image_url,
                                              retry=5,


### PR DESCRIPTION
subreddit css may contain protocol independent urls like `//a.thumbs.redditmedia.com/_6cQow5wLcUnICddDUm4btvZLuQOEsAiKwtazmQ9m_0.png`, but a schema is needed to fetch this urls. This tweaks the apng workaround code to match http:// https:// and // at the beginning of an url and replace it with the s3 url.
